### PR TITLE
codecs: fix fill_resizable_output_range

### DIFF
--- a/codecs/include/mgs/codecs/detail/default_converter.hpp
+++ b/codecs/include/mgs/codecs/detail/default_converter.hpp
@@ -42,7 +42,8 @@ ResizableOutputRange fill_resizable_output_range(
 
   // use max to force a read when max_remaining_size returns 0
   auto const max_size = is.max_remaining_size();
-  ResizableOutputRange ret(max_size, 0);
+  ResizableOutputRange ret;
+  ret.resize(max_size);
 
   auto to_read = std::max<mgs::ssize_t>(max_size, 1);
   auto it = begin(ret);
@@ -69,7 +70,8 @@ ResizableOutputRange fill_resizable_output_range(
 
   constexpr auto block_size = 256;
 
-  ResizableOutputRange ret(block_size, 0);
+  ResizableOutputRange ret;
+  ret.resize(block_size);
 
   auto total_read = size_type{0};
   auto it = begin(ret);
@@ -97,7 +99,7 @@ private:
             typename SizeType = typename R::size_type,
             typename = std::enable_if_t<
                 meta::is_default_constructible<R>::value &&
-                // Keep those in C++17 as well, fill_resizable_container
+                // Keep those in C++17 as well, fill_resizable_output_range
                 // relies on NRVO, not on Guaranteed Copy Elision.
                 (meta::is_copyable<R>::value || meta::is_movable<R>::value) &&
                 meta::is_detected<meta::detected::member_functions::resize,

--- a/codecs/test/test_codecs.cpp
+++ b/codecs/test/test_codecs.cpp
@@ -13,6 +13,8 @@
 #include <mgs/codecs/concepts/codec_output.hpp>
 #include <mgs/codecs/output_traits.hpp>
 #include <mgs/exceptions/unexpected_eof_error.hpp>
+#include <mgs/meta/concepts/input_iterator.hpp>
+#include <mgs/meta/concepts/sentinel_for.hpp>
 
 #include "codec_helpers.hpp"
 
@@ -49,6 +51,111 @@ struct valid_type
   {
     return vec.end();
   }
+};
+
+class string_wrapper : std::string
+{
+public:
+  using base_t = std::string;
+
+  string_wrapper() = default;
+
+  template <typename I, typename S>
+  string_wrapper(meta::input_iterator<I> begin, meta::sentinel_for<S, I> end)
+    : base_t(begin, end)
+  {
+  }
+
+  string_wrapper(base_t::value_type const* s, std::size_t size)
+    : base_t(s, size)
+  {
+  }
+
+  explicit string_wrapper(base_t const& s) : base_t(s)
+  {
+  }
+
+  explicit string_wrapper(base_t&& s) : base_t(std::move(s))
+  {
+  }
+
+  base_t const& string() const noexcept
+  {
+    return *this;
+  }
+
+  void swap(string_wrapper& other) noexcept(
+      noexcept(std::declval<base_t&>().swap(other)))
+  {
+    this->base_t::swap(other);
+  }
+
+  // std::string interface
+
+  // Member types
+  using base_t::allocator_type;
+  using base_t::const_iterator;
+  using base_t::const_pointer;
+  using base_t::const_reference;
+  using base_t::const_reverse_iterator;
+  using base_t::difference_type;
+  using base_t::iterator;
+  using base_t::pointer;
+  using base_t::reference;
+  using base_t::reverse_iterator;
+  using base_t::size_type;
+  using base_t::traits_type;
+  using base_t::value_type;
+
+  // Element access
+  using base_t::at;
+  using base_t::operator[];
+  using base_t::back;
+  using base_t::c_str;
+  using base_t::data;
+  using base_t::front;
+
+  // Iterators
+  using base_t::begin;
+  using base_t::cbegin;
+  using base_t::crbegin;
+  using base_t::rbegin;
+
+  using base_t::cend;
+  using base_t::crend;
+  using base_t::end;
+  using base_t::rend;
+
+  // Capacity
+  using base_t::capacity;
+  using base_t::empty;
+  using base_t::length;
+  using base_t::max_size;
+  using base_t::reserve;
+  using base_t::shrink_to_fit;
+  using base_t::size;
+
+  // Operations
+  using base_t::append;
+  using base_t::clear;
+  using base_t::erase;
+  using base_t::insert;
+  using base_t::pop_back;
+  using base_t::push_back;
+  using base_t::operator+=;
+  using base_t::compare;
+  using base_t::copy;
+  using base_t::replace;
+  using base_t::resize;
+  using base_t::substr;
+
+  // Search
+  using base_t::find;
+  using base_t::find_first_not_of;
+  using base_t::find_first_of;
+  using base_t::find_last_not_of;
+  using base_t::find_last_of;
+  using base_t::rfind;
 };
 
 struct valid_codec_traits
@@ -148,6 +255,8 @@ TEST_CASE("codecs")
     SECTION("User-defined types")
     {
       test_helpers::basic_codec_tests<valid_codec, valid_type>(input, input);
+      test_helpers::basic_codec_tests<valid_codec, string_wrapper>(input,
+                                                                   input);
     }
 
     SECTION("Common tests")


### PR DESCRIPTION
Both overloads were using a constructor that was not part of the
constraints of ResizableOutputRange.